### PR TITLE
Added animated link mixin

### DIFF
--- a/base/_mixins.scss
+++ b/base/_mixins.scss
@@ -505,3 +505,28 @@
 	   -moz-backface-visibility: $value;
 			backface-visibility: $value;
 }
+
+// -----------------------------------------
+
+  // Animated link that has a fade-in underline
+
+// -------------------------------------------
+
+// example: @include animate-link($screenGreen, $gothamMedium, 14);
+
+@mixin animate-link($color, $font, $fontSize) {
+  font-family:$font;
+  
+  @include single-transition(border, 0.2s, ease-in-out, 0);
+  text-decoration:none;
+
+  color: $color;
+  border-bottom:1px solid transparent;
+
+  @include rem("font-size", $fontSize);
+  
+  &:focus,
+  &:hover {
+    border-color: $color;
+  }
+}


### PR DESCRIPTION
Quick mixin that lets you turn your `<a href="">` into subtle animated links. Simply specify the color, font, and font-size, and you can give your links a nice fade-in underline.

Usage:

     a, a:link {
        @include animated-link(#20c05c, 'Helvetica', 14px);
     }
    

The result looks something like this. You can also see it on <a href="https://evernote.com/products/">Evernote Products</a>.

<img src="http://cdn.makeagif.com/media/1-15-2015/v02QON.gif" alt="animated link gif"/>