### PR TITLE
use tab indentation in markdown

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,4 +18,5 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 
 [*.md]
+indent_style = tab
 trim_trailing_whitespace = false


### PR DESCRIPTION
use tabs instead of spaces in markdown because otherwise code blocks and lists may break in some cases
