### PR TITLE
Add placeholder color compatibility for Firefox 19+

### DIFF
--- a/base/mixins/_placeholder.scss
+++ b/base/mixins/_placeholder.scss
@@ -15,6 +15,10 @@
     color: $color
   }
 
+  &::-moz-placeholder {
+    color: $color
+  }
+
   &::-webkit-input-placeholder {
     color: $color
   }


### PR DESCRIPTION
While using pieces of your project to create my own mixins, I noticed Firefox wasn't setting the placeholder color correctly.  After some digging, I found the solution [here](https://css-tricks.com/snippets/css/style-placeholder-text/).